### PR TITLE
Add support for customizing jenkins_pkg_url

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -234,5 +234,5 @@ jenkins_pipeline_library_approved_signatures_present:
 # geerlingguy.jenkins sets a sensible default if this is empty
 # Packages are retrieved using:
 #   url: "{{ jenkins_pkg_url }}/jenkins_{{ jenkins_version }}_all.deb"
-jenkins_pipeline_library_jenkins_pkg_url = ""
+jenkins_pipeline_library_jenkins_pkg_url: ""
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -229,3 +229,10 @@ jenkins_pipeline_library_approved_signatures_present:
   - method java.util.Calendar set int int
   - staticMethod org.codehaus.groovy.runtime.DateGroovyMethods format java.util.Calendar java.lang.String
   - method java.lang.Class getCanonicalName
+
+# Alternative URL to use for retrieving jenkins packages
+# geerlingguy.jenkins sets a sensible default if this is empty
+# Packages are retrieved using:
+#   url: "{{ jenkins_pkg_url }}/jenkins_{{ jenkins_version }}_all.deb"
+jenkins_pipeline_library_jenkins_pkg_url = ""
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,6 +29,7 @@ dependencies:
       jenkins_version: "{{ jenkins_pipeline_library_jenkins_version }}",
       jenkins_process_user: "{{ jenkins_pipeline_library_jenkins_process_user }}",
       jenkins_process_group: "{{ jenkins_pipeline_library_jenkins_process_group }}",
+      jenkins_pkg_url: "{{ jenkins_pipeline_library_jenkins_pkg_url }}",
       tags: ['wcm_io_devops.jenkins_pipeline_library.jenkins-installation'],
       # only setup jenkins when enabled
       when: jenkins_pipeline_library_jenkins_install | bool


### PR DESCRIPTION
Simply adds role variable that gets passed into inner geerlingguy.jenkins role's jenkins_pkg_url variable. This enabled me to workaround package mirror connectivity issues encountered when testing this role for jenkins master provisioning. As such it seems generally useful.

See issue #25 for details. 