### PR TITLE
Add role vars to specify Jenkins and Java args

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -234,5 +234,5 @@ jenkins_pipeline_library_approved_signatures_present:
 # geerlingguy.jenkins sets a sensible default if this is empty
 # Packages are retrieved using:
 #   url: "{{ jenkins_pkg_url }}/jenkins_{{ jenkins_version }}_all.deb"
-jenkins_pipeline_library_jenkins_pkg_url = ""
+jenkins_pipeline_library_jenkins_pkg_url: ""
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -229,3 +229,10 @@ jenkins_pipeline_library_approved_signatures_present:
   - method java.util.Calendar set int int
   - staticMethod org.codehaus.groovy.runtime.DateGroovyMethods format java.util.Calendar java.lang.String
   - method java.lang.Class getCanonicalName
+
+# Alternative URL to use for retrieving jenkins packages
+# geerlingguy.jenkins sets a sensible default if this is empty
+# Packages are retrieved using:
+#   url: "{{ jenkins_pkg_url }}/jenkins_{{ jenkins_version }}_all.deb"
+jenkins_pipeline_library_jenkins_pkg_url = ""
+

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -236,3 +236,8 @@ jenkins_pipeline_library_approved_signatures_present:
 #   url: "{{ jenkins_pkg_url }}/jenkins_{{ jenkins_version }}_all.deb"
 jenkins_pipeline_library_jenkins_pkg_url: ""
 
+# Extra Java options for the Jenkins launch command configured in the init file.
+# Defaults to same default as geerlingguy's default
+jenkins_pipline_library_jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
+
+

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -222,7 +222,12 @@ jenkins_pipeline_library_approved_signatures_present:
   - method java.util.List indexOf java.lang.Object
   - new java.util.ArrayList
   # allow creation of ExtendedChoiceParameterDefinition
-  - new com.cwctravel.hudson.plugins.extended_choice_parameter.ExtendedChoiceParameterDefinition java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String boolean boolean int java.lang.String java.lang.String
+  - new com.cwctravel.hudson.plugins.extended_choice_parameter.ExtendedChoiceParameterDefinition
+    java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String
+    java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String
+    java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String
+    java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String java.lang.String
+    java.lang.String java.lang.String boolean boolean int java.lang.String java.lang.String
   - new java.text.SimpleDateFormat java.lang.String java.util.Locale
   - method java.text.DateFormat parse java.lang.String
   - method java.util.Calendar setTime java.util.Date
@@ -239,5 +244,4 @@ jenkins_pipeline_library_jenkins_pkg_url: ""
 # Extra Java options for the Jenkins launch command configured in the init file.
 # Defaults to same default as geerlingguy's default
 jenkins_pipline_library_jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
-
-
+jenkins_pipeline_library_jenkins_args: ""

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,7 +30,7 @@ dependencies:
       jenkins_process_user: "{{ jenkins_pipeline_library_jenkins_process_user }}",
       jenkins_process_group: "{{ jenkins_pipeline_library_jenkins_process_group }}",
       jenkins_pkg_url: "{{ jenkins_pipeline_library_jenkins_pkg_url }}",
-      jenkins_java_options: "{{ jenkins_pipeline_library_jenkins_java_options }}"
+      jenkins_java_options: "{{ jenkins_pipeline_library_jenkins_java_options }}",
       tags: ['wcm_io_devops.jenkins_pipeline_library.jenkins-installation'],
       # only setup jenkins when enabled
       when: jenkins_pipeline_library_jenkins_install | bool

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,49 +13,55 @@ galaxy_info:
     - stretch
 
   galaxy_tags:
-    - jenkins
-    - pipeline
-    - wcmio
+  - jenkins
+  - pipeline
+  - wcmio
 
 dependencies:
-  # install jenkins
-  - { role: geerlingguy.jenkins,
-      version: 3.7.0,
-      jenkins_admin_username: "{{ jenkins_pipeline_library_admin_username }}",
-      jenkins_admin_password: "{{ jenkins_pipeline_library_admin_password }}",
-      jenkins_http_port: "{{ jenkins_pipeline_library_jenkins_port }}",
-      jenkins_home: "{{ jenkins_pipeline_library_jenkins_home }}",
-      jenkins_hostname: "{{ jenkins_pipeline_library_jenkins_hostname }}",
-      jenkins_version: "{{ jenkins_pipeline_library_jenkins_version }}",
-      jenkins_process_user: "{{ jenkins_pipeline_library_jenkins_process_user }}",
-      jenkins_process_group: "{{ jenkins_pipeline_library_jenkins_process_group }}",
-      jenkins_pkg_url: "{{ jenkins_pipeline_library_jenkins_pkg_url }}",
-      jenkins_java_options: "{{ jenkins_pipeline_library_jenkins_java_options }}",
-      tags: ['wcm_io_devops.jenkins_pipeline_library.jenkins-installation'],
-      # only setup jenkins when enabled
-      when: jenkins_pipeline_library_jenkins_install | bool
-   }
-  # install plugins
-  - { role: wcm_io_devops.jenkins_plugins,
-      version: 1.2.2,
-      jenkins_plugins_admin_username: "{{ jenkins_pipeline_library_admin_username }}",
-      jenkins_plugins_admin_password: "{{ jenkins_pipeline_library_admin_password }}",
-      jenkins_plugins_jenkins_home: "{{ jenkins_pipeline_library_jenkins_home }}",
-      jenkins_plugins_jenkins_hostname: "{{ jenkins_pipeline_library_jenkins_hostname }}",
-      jenkins_plugins_jenkins_port: "{{ jenkins_pipeline_library_jenkins_port }}",
-      jenkins_plugins_jenkins_url_prefix: "{{ jenkins_pipeline_library_jenkins_url_prefix }}",
-      jenkins_plugins_present: "{{ jenkins_pipeline_library_plugins_present }}",
-      jenkins_plugins_absent: "{{ jenkins_pipeline_library_plugins_absent }}",
-   }
-  # configure script security for jenkins-pipeline-library
-  - { role: wcm_io_devops.jenkins_script_security,
-      version: 1.1.2,
-      jenkins_script_security_admin_username: "{{ jenkins_pipeline_library_admin_username }}",
-      jenkins_script_security_admin_password: "{{ jenkins_pipeline_library_admin_password }}",
-      jenkins_script_security_jenkins_home: "{{ jenkins_pipeline_library_jenkins_home }}",
-      jenkins_script_security_jenkins_hostname: "{{ jenkins_pipeline_library_jenkins_hostname }}",
-      jenkins_script_security_jenkins_port: "{{ jenkins_pipeline_library_jenkins_port }}",
-      jenkins_script_security_jenkins_url_prefix: "{{ jenkins_pipeline_library_jenkins_url_prefix }}",
-      jenkins_script_security_approved_signatures_present: "{{ jenkins_pipeline_library_approved_signatures_present }}",
-      tags: ['wcm_io_devops.jenkins_pipeline_library.jenkins_script_security']
-    }
+# install jenkins
+- { role: geerlingguy.jenkins,
+    version: 3.7.0,
+    jenkins_admin_username: "{{ jenkins_pipeline_library_admin_username }}",
+    jenkins_admin_password: "{{ jenkins_pipeline_library_admin_password }}",
+    jenkins_http_port: "{{ jenkins_pipeline_library_jenkins_port }}",
+    jenkins_home: "{{ jenkins_pipeline_library_jenkins_home }}",
+    jenkins_hostname: "{{ jenkins_pipeline_library_jenkins_hostname }}",
+    jenkins_version: "{{ jenkins_pipeline_library_jenkins_version }}",
+    jenkins_process_user: "{{ jenkins_pipeline_library_jenkins_process_user }}",
+    jenkins_process_group: "{{ jenkins_pipeline_library_jenkins_process_group }}",
+    jenkins_pkg_url: "{{ jenkins_pipeline_library_jenkins_pkg_url }}",
+    jenkins_java_options: "{{ jenkins_pipeline_library_jenkins_java_options }}",
+    jenkins_init_changes: [
+      { option: "JENKINS_ARGS",
+        value: "{{ jenkins_pipeline_library_jenkins_args }}" },
+      { option: "{{ jenkins_java_options_env_var }}",  # this var set in jenkins role per OS
+        value: "{{ jenkins_java_options }}" }
+    ],
+    tags: ['wcm_io_devops.jenkins_pipeline_library.jenkins-installation'],
+    # only setup jenkins when enabled
+    when: jenkins_pipeline_library_jenkins_install | bool
+}
+# install plugins
+- { role: wcm_io_devops.jenkins_plugins,
+    version: 1.2.2,
+    jenkins_plugins_admin_username: "{{ jenkins_pipeline_library_admin_username }}",
+    jenkins_plugins_admin_password: "{{ jenkins_pipeline_library_admin_password }}",
+    jenkins_plugins_jenkins_home: "{{ jenkins_pipeline_library_jenkins_home }}",
+    jenkins_plugins_jenkins_hostname: "{{ jenkins_pipeline_library_jenkins_hostname }}",
+    jenkins_plugins_jenkins_port: "{{ jenkins_pipeline_library_jenkins_port }}",
+    jenkins_plugins_jenkins_url_prefix: "{{ jenkins_pipeline_library_jenkins_url_prefix }}",
+    jenkins_plugins_present: "{{ jenkins_pipeline_library_plugins_present }}",
+    jenkins_plugins_absent: "{{ jenkins_pipeline_library_plugins_absent }}",
+}
+# configure script security for jenkins-pipeline-library
+- { role: wcm_io_devops.jenkins_script_security,
+    version: 1.1.2,
+    jenkins_script_security_admin_username: "{{ jenkins_pipeline_library_admin_username }}",
+    jenkins_script_security_admin_password: "{{ jenkins_pipeline_library_admin_password }}",
+    jenkins_script_security_jenkins_home: "{{ jenkins_pipeline_library_jenkins_home }}",
+    jenkins_script_security_jenkins_hostname: "{{ jenkins_pipeline_library_jenkins_hostname }}",
+    jenkins_script_security_jenkins_port: "{{ jenkins_pipeline_library_jenkins_port }}",
+    jenkins_script_security_jenkins_url_prefix: "{{ jenkins_pipeline_library_jenkins_url_prefix }}",
+    jenkins_script_security_approved_signatures_present: "{{ jenkins_pipeline_library_approved_signatures_present }}",
+    tags: ['wcm_io_devops.jenkins_pipeline_library.jenkins_script_security']
+}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,6 +30,7 @@ dependencies:
       jenkins_process_user: "{{ jenkins_pipeline_library_jenkins_process_user }}",
       jenkins_process_group: "{{ jenkins_pipeline_library_jenkins_process_group }}",
       jenkins_pkg_url: "{{ jenkins_pipeline_library_jenkins_pkg_url }}",
+      jenkins_java_options: "{{ jenkins_pipeline_library_jenkins_java_options }}"
       tags: ['wcm_io_devops.jenkins_pipeline_library.jenkins-installation'],
       # only setup jenkins when enabled
       when: jenkins_pipeline_library_jenkins_install | bool

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,6 +29,7 @@ dependencies:
       jenkins_version: "{{ jenkins_pipeline_library_jenkins_version }}",
       jenkins_process_user: "{{ jenkins_pipeline_library_jenkins_process_user }}",
       jenkins_process_group: "{{ jenkins_pipeline_library_jenkins_process_group }}",
+      jenkins_pkg_url: "{{ jenkins_pipeline_library_jenkins_pkg_url }}",
       tags: ['wcm_io_devops.jenkins_pipeline_library.jenkins-installation'],
       # only setup jenkins when enabled
       when: jenkins_pipeline_library_jenkins_install | bool


### PR DESCRIPTION
These are needed for a LOT of reasons when working with Jenkins. In my case, I'm customizing the Jenkins args to enable https:

```
# Jenkins args documented here: https://wiki.jenkins.io/display/JENKINS//Starting+and+Accessing+Jenkins
jenkins_pipeline_library_jenkins_args: "--httpsPort=8443 --httpsKeyStore=/etc/jenkins/host.jks --httpsKeyStorePassword={{ jenkins_java_keystore_password }} --httpsListenAddress=0.0.0.0"
``` 

and Java args to customize logging, sanitize workspace paths, and put the JVM in alignment with Cloudbees Best Practices:

```
        # Notes about java options:
        # 1. Cloudbees JVM Best Practices:
        #   https://www.jenkins.io/blog/2016/11/21/gc-tuning/
        #   https://docs.cloudbees.com/docs/admin-resources/latest/jvm-troubleshooting/#suggested-specifications
        #   https://support.cloudbees.com/hc/en-us/articles/222446987-Prepare-Jenkins-for-Support
        #   https://support.cloudbees.com/hc/en-us/articles/204859670-Java-Heap-settings-best-practice
        # 2. yaml folded style string format (>) replaces newlines and leading indentation with a single space
        #   Trailing dash (>-) means newline is eliminated at the end of resulting string.
        # 3. -Dhudson.slaves.WorkspaceList=- is there bc poky build cannot handle @ in paths.
        jenkins_java_options_list:
          - "-Djenkins.install.runSetupWizard=false"
          - "-Dhudson.slaves.WorkspaceList=-"
          - "-Dorg.apache.commons.jelly.tags.fmt.timeZone=America/Vancouver"
          - "-Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true"
          - "-Dcom.cloudbees.workflow.rest.external.JobExt.maxRunsPerJob=16"
          # Change Content Security Policy to enable embedding html in job/build pages via htmlpublisher
          # Details:
          # * https://support.cloudbees.com/hc/en-us/articles/360034545912-What-is-Content-Security-Policy-and-how-does-it-impact-Jenkins-
          # * https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy
          # * Must include literal \" in string, which is copied into a double-quoted string as JAVA_ARGS in /etc/default/jenkins
          - "-Dhudson.model.DirectoryBrowserSupport.CSP=\\\"sandbox allow-same-origin allow-scripts allow-forms; default-src 'self' 'unsafe-inline' data:; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src 'self' 'unsafe-inline';\\\""
          # Extend default docker daemon timeout (from 180sec)
          # https://issues.jenkins-ci.org/browse/JENKINS-42322?focusedCommentId=303679&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-303679
          - "-Dorg.jenkinsci.plugins.docker.workflow.client.DockerClient.CLIENT_TIMEOUT=300"
          - "-Djenkins.model.Jenkins.logStartupPerformance=true"
          - "-Xmx{{ (ansible_memtotal_mb / 4 if ansible_memtotal_mb / 4 <= 16384 else 16384) | round | int }}m"
          - "-Xms{{ (ansible_memtotal_mb / 4 if ansible_memtotal_mb / 4 <= 16384 else 16384) | round | int }}m"
          - "-XX:+AlwaysPreTouch"
          - "-XX:+HeapDumpOnOutOfMemoryError"
          - "-XX:HeapDumpPath={{ jenkins_path_to_gc_and_heap_dump }}"
          - "-XX:+UseG1GC"
          - "-XX:+UseStringDeduplication"
          - "-XX:+ParallelRefProcEnabled"
          - "-XX:+DisableExplicitGC"
          - "-XX:+UnlockDiagnosticVMOptions"
          - "-XX:+UnlockExperimentalVMOptions"
          - "-verbose:gc"
          # See here for details: https://c-guntur.github.io/java-gc/#/8/2
          # - "-Xloggc:{{ jenkins_path_to_gc_and_heap_dump }}/gc-%t.log"  # unrecognized VM option
          - "-Xlog:gc:{{ jenkins_path_to_gc_and_heap_dump }}/gc-%t.log"
          # - "-XX:NumberOfGCLogFiles=2"  # deprecated
          # - "-XX:+UseGCLogFileRotation"  # deprecated
          # - "-XX:GCLogFileSize=100m"  # deprecated
          - "-XX:+PrintGC"
          # - "-XX:+PrintGCDateStamps"  # deprecated
          - "-XX:+PrintGCDetails"
          # - "-XX:+PrintHeapAtGC"  # unrecognized VM option
          # - "-XX:+PrintGCCause"  # unrecognized VM option
          # - "-XX:+PrintTenuringDistribution"  # unrecognized VM option
          # - "-XX:+PrintReferenceGC"  # unrecognized VM option
          # - "-XX:+PrintAdaptiveSizePolicy"  # unrecognized VM option
          - "-XX:ErrorFile=/hs_err_%p.log"
          - "-XX:+LogVMOutput"
          - "-XX:LogFile={{ jenkins_path_to_gc_and_heap_dump }}/jvm.log"
          # https://www.jenkins.io/doc/book/system-administration/viewing-logs/#debug-logging-in-jenkins
          - "-Djava.util.logging.config.file={{ jenkins_path_to_logging_properties_file }}"
        jenkins_pipeline_library_jenkins_java_options: "{{ jenkins_java_options_list | join(' ') }}"
```